### PR TITLE
fix crashing when logout due to failure to modify PFInstallation

### DIFF
--- a/babyry/PushNotification.m
+++ b/babyry/PushNotification.m
@@ -136,6 +136,13 @@
 + (void)removeSelfUserIdFromChannels:(PushNotificationBlock)block
 {
     PFInstallation *currentInstallation = [PFInstallation currentInstallation];
+    
+    // currentInstallationが保存できていない場合(simulator or 起動時にout of network)は
+    // 後続の処理で落ちるのでlogout処理だけやる
+    if (!currentInstallation.objectId) {
+        block();
+        return;
+    }
     // 自分のuserIdを消す
     NSString *targetChannel = [NSString stringWithFormat:@"userId_%@", [PFUser currentUser][@"userId"]];
     [currentInstallation removeObject:targetChannel forKey:@"channels"];


### PR DESCRIPTION
@waremon @kenjiszk 
例のlogout時にcrashする件の対応しましたー
レビューよろです

原因は
- シミュレータではdeviceTokenがないのでInstallationの保存に失敗する
  - 詳細は終えてないけど、既にdeviceTokenがnullのレコードがあったら失敗とかかな
- 保存に失敗するから[PFInstallation currentInstallation]が未保存のobject(objectIdがない)
- ログアウトしようとして未保存のPFInstallationオブジェクトを操作しようとすると落ちる
  - 未保存のPFInstallationオブジェクトをいじろうとするとexceptionになるのはParseの仕様

ということで、PFInstallationオブジェクトにobjectIdがない場合は、Installationから自分のuserIdを抜く処理をしないことにしてます。
