### PR TITLE
use fullsize image for today's cell

### DIFF
--- a/babyry/PageContentViewController.m
+++ b/babyry/PageContentViewController.m
@@ -475,7 +475,7 @@
                             [totalImageNum replaceObjectAtIndex:i withObject:[NSNumber numberWithInt:1]];
                         }
                        
-                        // fullsizeのcacheがあれば消す
+                        // 2日以上前のfullsizeのcacheは不要なのであれば消す
                         [ImageCache removeCache:[NSString stringWithFormat:@"%@%@", _childObjectId, [date stringValue]]];
                     }
                 } else {
@@ -536,11 +536,12 @@
                         if ([queue[@"imageType"] isEqualToString:@"fullsize"]) {
                             // fullsizeのimageをcache
                             [ImageCache setCache:[NSString stringWithFormat:@"%@%@", _childObjectId, ymd] image:getResult.body];
-                        } else {
-                            UIImage *thumbImage = [ImageCache makeThumbNail:[UIImage imageWithData:getResult.body]];
-                            NSData *thumbData = [[NSData alloc] initWithData:UIImageJPEGRepresentation(thumbImage, 0.7f)];
-                            [ImageCache setCache:[NSString stringWithFormat:@"%@%@thumb", _childObjectId, ymd] image:thumbData];
                         }
+                        // thumbnailは常に作る
+                        // なので、fullsizeのcacheが作られた場合、常にtimestampはthumbnailと同じになる
+                        UIImage *thumbImage = [ImageCache makeThumbNail:[UIImage imageWithData:getResult.body]];
+                        NSData *thumbData = [[NSData alloc] initWithData:UIImageJPEGRepresentation(thumbImage, 0.7f)];
+                        [ImageCache setCache:[NSString stringWithFormat:@"%@%@thumb", _childObjectId, ymd] image:thumbData];
                     } else {
                         [Logger writeOneShot:@"crit" message:[NSString stringWithFormat:@"Error in getRequsetOfS3 in setImageCache : %@", task.error]];
                     }


### PR DESCRIPTION
@waremon @kenjiszk 
トップの大きいcellにfullsizeの画像を出す対応です。

だいぶカオスな感じになってるので真面目にリファクタリングしたいところやけど、
そのせいで審査に間に合わないってのもアレなんで取り急ぎ今の状態で対応doneにしますー

やったこと
- 画像をloadした時点で大きいcellの画像の場合はfullsizeのcacheを作り、さらにcellを作る時にfullsizeのcacheを読み込む
- section == 0 && row == 0  って分岐が目立ったので isTodayってmethodを作った
