### PR TITLE
change -1 to 0 at init badge

### DIFF
--- a/babyry/PushNotification.m
+++ b/babyry/PushNotification.m
@@ -105,7 +105,7 @@
     if (currentInstallation.objectId) {
         [currentInstallation refresh];
     }
-    if([currentInstallation[@"badge"] isEqualToNumber:[NSNumber numberWithInt:-1]]) {
+    if([currentInstallation[@"badge"] intValue] < 0) {
         currentInstallation[@"badge"] = [NSNumber numberWithInt:0];
     }
     [currentInstallation addUniqueObject:[NSString stringWithFormat:@"userId_%@", currentUser[@"userId"]] forKey:@"channels"];


### PR DESCRIPTION
@hirata-motoi 

badgeに-1がくるとParse的にエラーになるので0を入れ直す
(iOS的には-1でbadgeなし的な仕様なのかな(?)、ドキュメント読んでないですが)
