### PR TITLE
fix bug about env && throw exception if env is invalid

### DIFF
--- a/babyry/AppDelegate.m
+++ b/babyry/AppDelegate.m
@@ -27,13 +27,13 @@
         self.window.rootViewController = rootViewController;
     }
    
+    // global変数
+    [self setGlobalVariables];
+    
     // CoreData
     [MagicalRecord setupCoreDataStackWithStoreNamed:@"babyry.sqlite"];
     [self setupFirstLaunchUUID];
     
-    // global変数
-    [self setGlobalVariables];
-
     // Parse Authentification
     [Parse setApplicationId:[Config secretConfig][@"ParseApplicationId"] clientKey:[Config secretConfig][@"ParseClientKey"]];
 

--- a/babyry/Config.m
+++ b/babyry/Config.m
@@ -8,6 +8,7 @@
 
 #import "Config.h"
 #import "MaintenanceViewController.h"
+#import "Logger.h"
 
 @implementation Config
 
@@ -30,9 +31,14 @@ static NSMutableDictionary *_secretConfig = nil;
 + (NSMutableDictionary *)config
 {
     if (_config == nil) {
-        NSString *configName = ([[app env] isEqualToString:@"prod"])
-            ? @"babyry-config.plist"
-            : @"babyrydev-config.plist";
+        NSString *configName =
+            ([[app env] isEqualToString:@"prod"]) ? @"babyry-config.plist"    :
+            ([[app env] isEqualToString:@"dev"])  ? @"babyrydev-config.plist" : nil;
+        if (configName == nil) {
+            NSString *exceptionString = [NSString stringWithFormat:@"invalid configName due to unknown env:%@", [app env]];
+            [Logger writeOneShot:@"crit" message:exceptionString];
+            @throw exceptionString;
+        }
         _config = [self load:configName];
     }
     
@@ -42,9 +48,14 @@ static NSMutableDictionary *_secretConfig = nil;
 + (NSMutableDictionary *)secretConfig
 {
     if (_secretConfig == nil) {
-        NSString *configName = ([[app env] isEqualToString:@"prod"])
-            ? @"babyry-secret-config.plist"
-            : @"babyrydev-secret-config.plist";
+        NSString *configName =
+            ([[app env] isEqualToString:@"prod"]) ? @"babyry-secret-config.plist"    :
+            ([[app env] isEqualToString:@"dev"])  ? @"babyrydev-secret-config.plist" : nil;
+        if (configName == nil) {
+            NSString *exceptionString = [NSString stringWithFormat:@"invalid secretConfigName due to unknown env:%@", [app env]];
+            [Logger writeOneShot:@"crit" message:exceptionString];
+            @throw exceptionString;
+        }
         _secretConfig = [self load:configName];
     }
     

--- a/babyry/PageContentViewController.m
+++ b/babyry/PageContentViewController.m
@@ -531,7 +531,7 @@
                 
                 AWSS3GetObjectRequest *getRequest = [AWSS3GetObjectRequest new];
                 getRequest.bucket = [Config config][@"AWSBucketName"];
-                                                      
+
                 getRequest.key = [NSString stringWithFormat:@"%@/%@", [NSString stringWithFormat:@"ChildImage%ld", (long)[_childProperty[@"childImageShardIndex"] integerValue]], queue[@"objectId"]];
                 // no-cache必須
                 getRequest.responseCacheControl = @"no-cache";
@@ -570,7 +570,6 @@
             }
         }
     } else {
-        NSLog(@"get image cache queue end!");
         if (reload) {
             [_pageContentCollectionView reloadData];
         }


### PR DESCRIPTION
@kenjiszk @waremon 

prodでdev用のconfigをよんじゃってた件の対応です。

Config.config、Config.secretConfigはどっちもシングルトンにしてて実際にplistを読むのは最初だけ。
CoreDataの対応の時にAppDelegate.setupFirstLaunchUUIDをsetGlobalVariables(envを設定)よりも前に書いちゃったので、
envが空の状態でConfig.configがcallされてました。
三項演算子の関係で、envがprod以外だったらdev用を読む(逆だと開発中の時点で死んでた)になってたので、
prodのアプリでdevのbucket名が使われておりました。
SecretConfigの方はsetGlobalVariablesの後に呼ばれてたので問題なしでした。

自作自演でスマセン！！

なので、以下対応しました。
- AppDelegate内でsetupFirstLaunchUUIDよりもsetGlobalVariablesを先に呼ぶように修正
- 再発防止策として、Config内でenvがprod、dev以外だった場合はexceptionを投げるように修正

ざっと目を通してもらえると！
