### PR TITLE
fix bug

### DIFF
--- a/babyry/ChooseRegisterStepViewController.m
+++ b/babyry/ChooseRegisterStepViewController.m
@@ -200,7 +200,7 @@
         } else {
             if (!user.isNew) {
                 UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"登録済みのアカウントです"
-                                                                message:@"既に登録頂いているアカウントですので、ログインしました。"
+                                                                message:@"既に登録済みのアカウントです。\n新規登録はせずログインします。"
                                                                delegate:nil
                                                       cancelButtonTitle:nil
                                                       otherButtonTitles:@"OK", nil];
@@ -215,6 +215,11 @@
             }
             
             if (user[@"email"] && ![user[@"email"] isEqualToString:@""]) {
+                [self dismissViewControllerAnimated:YES completion:NULL];
+                return;
+            }
+            
+            if (user[@"emailCommon"] && ![user[@"emailCommon"] isEqualToString:@""]) {
                 [self dismissViewControllerAnimated:YES completion:NULL];
                 return;
             }

--- a/babyry/InputPinCodeViewController.m
+++ b/babyry/InputPinCodeViewController.m
@@ -90,7 +90,9 @@
     
     PFQuery *query = [PFQuery queryWithClassName:@"PincodeList"];
     [query whereKey:@"pinCode" equalTo:[NSNumber numberWithInt:[_pincodeField.text intValue]]];
-    [query whereKey:@"familyId" notEqualTo:[PFUser currentUser][@"familyId"]];
+    if ([PFUser currentUser] && [PFUser currentUser][@"familyId"]) {
+        [query whereKey:@"familyId" notEqualTo:[PFUser currentUser][@"familyId"]];
+    }
     [query findObjectsInBackgroundWithBlock:^(NSArray *objects, NSError *error){
         if (error) {
             UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"ネットワークエラー"


### PR DESCRIPTION
@hirata-motoi 

以下のバグを修正
- 自分の認証コードをはじく為に、notEqual:FamilyIdをいれていたが、まだFamilyIdが無い場合もあるのでifで分岐
- 新規でfacebookログインした時に、仮に既に登録済みのfacebookアカウントだった場合そのままログインさせるようにしていたが、その後の処理で強制的にログアウトさせられていたので修正
