### PR TITLE
improve image zooming

### DIFF
--- a/babyry/UploadViewController.m
+++ b/babyry/UploadViewController.m
@@ -219,6 +219,17 @@
     return _uploadedImageView;
 }
 
+- (void)scrollViewDidEndZooming:(UIScrollView *)scrollView withView:(UIView *)view atScale:(CGFloat)scale
+{
+    CGRect rect = view.frame;
+    if (rect.size.height < scrollView.frame.size.height) {
+        rect.origin.y = (scrollView.frame.size.height - rect.size.height)/2;
+    } else {
+        rect.origin.y = 0;
+    }
+    view.frame = rect;
+}
+
 - (void)disableNotificationHistories
 {
     NSString *type = @"imageUploaded";


### PR DESCRIPTION
@kenjiszk 
写真zoom時のあやしい挙動をなおしました。
- 横長の画像をzoomした時に画面の半端な位置に写真が配置される
  - 写真のサイズが変わってもimageView.frame.origin.yが変わっていなかったことが原因
  - 写真の縦が画面よりも小さいときは、zoom完了後にframeを補正して画面中央にくるように修正
- 画像を画面以上に拡大した時に、写真上端に45px程余計な空白が入る(その分写真下端の45px分が見づらくなる)
  - 文章での説明が難しいので細かい事は口頭で
  - zoom完了後に、画面よりも写真が大きかった場合はimageView.frame.origin.yを0にセットして回避
