### PR TITLE
fix bug of partnerapply

### DIFF
--- a/babyry.xcodeproj/project.pbxproj
+++ b/babyry.xcodeproj/project.pbxproj
@@ -18,7 +18,6 @@
 		882A6A26196B7D4A00E07D60 /* Config.m in Sources */ = {isa = PBXBuildFile; fileRef = 882A6A25196B7D4A00E07D60 /* Config.m */; };
 		882A6A28196BCE8000E07D60 /* 3_5_inch.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 882A6A27196BCE8000E07D60 /* 3_5_inch.storyboard */; };
 		8833BC831963C5BE0040FD2A /* MultiUploadPickerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8833BC821963C5BE0040FD2A /* MultiUploadPickerViewController.m */; };
-		883A92F019D2102F00F82A34 /* PartnerInviteEntity.m in Sources */ = {isa = PBXBuildFile; fileRef = 883A92EF19D2102F00F82A34 /* PartnerInviteEntity.m */; };
 		883A92F319D2257C00F82A34 /* PartnerWaitViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 883A92F219D2257C00F82A34 /* PartnerWaitViewController.m */; };
 		885A223719750DD20039B263 /* DateUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 885A223619750DD20039B263 /* DateUtils.m */; };
 		887CF8E21987822300B90C2E /* UIPlaceHolderTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 887CF8E11987822300B90C2E /* UIPlaceHolderTextView.m */; };
@@ -28,6 +27,7 @@
 		889002FB198F5EC7005775B5 /* ChildProfileViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 889002FA198F5EC7005775B5 /* ChildProfileViewController.m */; };
 		889002FE198F6B22005775B5 /* ChildProfileEditViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 889002FD198F6B22005775B5 /* ChildProfileEditViewController.m */; };
 		889F53E319DBFE4A009B3123 /* TransitionByPushNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = 889F53E219DBFE4A009B3123 /* TransitionByPushNotification.m */; };
+		889F53ED19EAE4F5009B3123 /* PartnerInviteEntity.m in Sources */ = {isa = PBXBuildFile; fileRef = 889F53EC19EAE4F5009B3123 /* PartnerInviteEntity.m */; };
 		88AA2FE9196C16D600F4B40C /* IntroFirstViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 88AA2FE8196C16D600F4B40C /* IntroFirstViewController.m */; };
 		88AA2FEF196CE9C500F4B40C /* MJPopupBackgroundView.m in Sources */ = {isa = PBXBuildFile; fileRef = 88AA2FEC196CE9C500F4B40C /* MJPopupBackgroundView.m */; };
 		88AA2FF0196CE9C500F4B40C /* UIViewController+MJPopupViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 88AA2FEE196CE9C500F4B40C /* UIViewController+MJPopupViewController.m */; };
@@ -256,8 +256,6 @@
 		8833BC811963C5BE0040FD2A /* MultiUploadPickerViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MultiUploadPickerViewController.h; sourceTree = "<group>"; };
 		8833BC821963C5BE0040FD2A /* MultiUploadPickerViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MultiUploadPickerViewController.m; sourceTree = "<group>"; };
 		8833BC871964F7700040FD2A /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = System/Library/Frameworks/ImageIO.framework; sourceTree = SDKROOT; };
-		883A92EE19D2102F00F82A34 /* PartnerInviteEntity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PartnerInviteEntity.h; sourceTree = "<group>"; };
-		883A92EF19D2102F00F82A34 /* PartnerInviteEntity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PartnerInviteEntity.m; sourceTree = "<group>"; };
 		883A92F119D2257C00F82A34 /* PartnerWaitViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PartnerWaitViewController.h; sourceTree = "<group>"; };
 		883A92F219D2257C00F82A34 /* PartnerWaitViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PartnerWaitViewController.m; sourceTree = "<group>"; };
 		885A223519750DD20039B263 /* DateUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DateUtils.h; sourceTree = "<group>"; };
@@ -276,6 +274,8 @@
 		889002FD198F6B22005775B5 /* ChildProfileEditViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ChildProfileEditViewController.m; sourceTree = "<group>"; };
 		889F53E119DBFE4A009B3123 /* TransitionByPushNotification.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TransitionByPushNotification.h; sourceTree = "<group>"; };
 		889F53E219DBFE4A009B3123 /* TransitionByPushNotification.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TransitionByPushNotification.m; sourceTree = "<group>"; };
+		889F53EB19EAE4F5009B3123 /* PartnerInviteEntity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PartnerInviteEntity.h; sourceTree = "<group>"; };
+		889F53EC19EAE4F5009B3123 /* PartnerInviteEntity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PartnerInviteEntity.m; sourceTree = "<group>"; };
 		88AA2FE7196C16D600F4B40C /* IntroFirstViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IntroFirstViewController.h; sourceTree = "<group>"; };
 		88AA2FE8196C16D600F4B40C /* IntroFirstViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IntroFirstViewController.m; sourceTree = "<group>"; };
 		88AA2FEB196CE9C500F4B40C /* MJPopupBackgroundView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MJPopupBackgroundView.h; sourceTree = "<group>"; };
@@ -1275,10 +1275,10 @@
 		F2AE04E319B2E66B00B39C6F /* CoreData */ = {
 			isa = PBXGroup;
 			children = (
+				889F53EB19EAE4F5009B3123 /* PartnerInviteEntity.h */,
+				889F53EC19EAE4F5009B3123 /* PartnerInviteEntity.m */,
 				F22F208419E46A600089A592 /* ChildPropertyEntity.h */,
 				F22F208519E46A600089A592 /* ChildPropertyEntity.m */,
-				883A92EE19D2102F00F82A34 /* PartnerInviteEntity.h */,
-				883A92EF19D2102F00F82A34 /* PartnerInviteEntity.m */,
 				F2D9350019C95DA8001F33D0 /* TutorialAttributes.h */,
 				F2D9350119C95DA8001F33D0 /* TutorialAttributes.m */,
 				F2D934FD19C9463E001F33D0 /* TutorialBestShot.h */,
@@ -1589,6 +1589,7 @@
 				F2305216198FE06E000F5E32 /* CellBackgroundViewToWaitUpload.m in Sources */,
 				F2694AFF19827013008239F6 /* UIColor+Hex.m in Sources */,
 				88B89FB8193B2D52009474DC /* PageContentViewController.m in Sources */,
+				889F53ED19EAE4F5009B3123 /* PartnerInviteEntity.m in Sources */,
 				F215DDC61973B4D30092C712 /* TagAlbumOperationViewController.m in Sources */,
 				F2FAA55C19DC16EA00546669 /* CloseButtonView.m in Sources */,
 				F2D9350C19C9848B001F33D0 /* TutorialNavigator+ShowMultiUpload.m in Sources */,
@@ -1674,7 +1675,6 @@
 				84ABD707194DBE8500BC3CDA /* Sequence.m in Sources */,
 				F21BBBD519CA6B6E002D4623 /* TutorialPartChangeExecView.m in Sources */,
 				F2D9350219C95DA8001F33D0 /* TutorialAttributes.m in Sources */,
-				883A92F019D2102F00F82A34 /* PartnerInviteEntity.m in Sources */,
 				88CFF4DC19938A0600B56481 /* CalenderLabel.m in Sources */,
 				F2D934ED19C75C69001F33D0 /* PageContentViewController+Logic+Tutorial.m in Sources */,
 				88AA2FEF196CE9C500F4B40C /* MJPopupBackgroundView.m in Sources */,

--- a/babyry/PartnerApply.m
+++ b/babyry/PartnerApply.m
@@ -16,9 +16,8 @@
 
 + (BOOL) linkComplete
 {
-    NSString *partnerInviteEntityKeyName = [Config config][@"PartnerInviteEntityKeyName"];
-    PartnerInviteEntity *pie = [PartnerInviteEntity MR_findFirstByAttribute:@"name" withValue:partnerInviteEntityKeyName];
-    if (!pie.linkComplete || [pie.linkComplete isEqual:[NSNumber numberWithBool:NO]]) {
+    PartnerInviteEntity *pie = [PartnerInviteEntity MR_findFirst];
+    if (!pie || !pie.linkComplete || [pie.linkComplete isEqual:[NSNumber numberWithBool:NO]]) {
         return NO;
     } else {
         return YES;
@@ -27,8 +26,7 @@
 
 + (void) setLinkComplete
 {
-    NSString *partnerInviteEntityKeyName = [Config config][@"PartnerInviteEntityKeyName"];
-    PartnerInviteEntity *pie = [PartnerInviteEntity MR_findFirstByAttribute:@"name" withValue:partnerInviteEntityKeyName];
+    PartnerInviteEntity *pie = [PartnerInviteEntity MR_findFirst];
     if ([pie.linkComplete isEqual:[NSNumber numberWithBool:YES]]) {
         return;
     }
@@ -38,15 +36,13 @@
     } else {
         PartnerInviteEntity *newPie = [PartnerInviteEntity MR_createEntity];
         newPie.linkComplete = [NSNumber numberWithBool:YES];
-        newPie.name = [Config config][@"PartnerInviteEntityKeyName"];
     }
     [[NSManagedObjectContext MR_defaultContext] MR_saveToPersistentStoreAndWait];
 }
 
 + (void) unsetLinkComplete
 {
-    NSString *partnerInviteEntityKeyName = [Config config][@"PartnerInviteEntityKeyName"];
-    PartnerInviteEntity *pie = [PartnerInviteEntity MR_findFirstByAttribute:@"name" withValue:partnerInviteEntityKeyName];
+    PartnerInviteEntity *pie = [PartnerInviteEntity MR_findFirst];
     if ([pie.linkComplete isEqual:[NSNumber numberWithBool:NO]]) {
         return;
     }
@@ -56,7 +52,6 @@
     } else {
         PartnerInviteEntity *newPie = [PartnerInviteEntity MR_createEntity];
         newPie.linkComplete = [NSNumber numberWithBool:NO];
-        newPie.name = [Config config][@"PartnerInviteEntityKeyName"];
     }
     [[NSManagedObjectContext MR_defaultContext] MR_saveToPersistentStoreAndWait];
 }

--- a/babyry/PartnerInviteEntity.h
+++ b/babyry/PartnerInviteEntity.h
@@ -2,7 +2,7 @@
 //  PartnerInviteEntity.h
 //  babyry
 //
-//  Created by Kenji Suzuki on 2014/09/24.
+//  Created by Kenji Suzuki on 2014/10/13.
 //  Copyright (c) 2014年 jp.co.meaning. All rights reserved.
 //
 
@@ -13,7 +13,6 @@
 @interface PartnerInviteEntity : NSManagedObject
 
 @property (nonatomic, retain) NSNumber * linkComplete;
-@property (nonatomic, retain) NSString * name;
 @property (nonatomic, retain) NSNumber * pinCode;
 
 @end

--- a/babyry/PartnerInviteEntity.m
+++ b/babyry/PartnerInviteEntity.m
@@ -2,7 +2,7 @@
 //  PartnerInviteEntity.m
 //  babyry
 //
-//  Created by Kenji Suzuki on 2014/09/24.
+//  Created by Kenji Suzuki on 2014/10/13.
 //  Copyright (c) 2014年 jp.co.meaning. All rights reserved.
 //
 
@@ -12,7 +12,6 @@
 @implementation PartnerInviteEntity
 
 @dynamic linkComplete;
-@dynamic name;
 @dynamic pinCode;
 
 @end

--- a/babyry/PartnerInviteViewController.m
+++ b/babyry/PartnerInviteViewController.m
@@ -60,8 +60,7 @@
     // その為、基本的にはしょっぱなでpinCodeを発行 & PincodeList(Parse)にレコード追加しておく (つまり、最初は1ユーザーに必ず1レコードが出来る)
     // パートナーひも付けが完了した場合にこのレコードは削除する
     // PincodeListに書き込んだらCoreDataに書き込んでおく、消したらCoreDataから消す
-    NSString *partnerInviteEntityKeyName = [Config config][@"PartnerInviteEntityKeyName"];
-    PartnerInviteEntity *pie = [PartnerInviteEntity MR_findFirstByAttribute:@"name" withValue:partnerInviteEntityKeyName];
+    PartnerInviteEntity *pie = [PartnerInviteEntity MR_findFirst];
     if (!pie || !pie.pinCode || [pie.pinCode isEqualToNumber:[NSNumber numberWithInt:0]]) {
         [self issuePinCode];
     } else {
@@ -202,7 +201,6 @@
         }
         
         PartnerInviteEntity *pie = [PartnerInviteEntity MR_createEntity];
-        pie.name = [Config config][@"PartnerInviteEntityKeyName"];
         pie.pinCode = _pinCode;
         [[NSManagedObjectContext MR_defaultContext] MR_saveToPersistentStoreAndWait];
     }];

--- a/babyry/babyry-coredata.xcdatamodeld/babyry-coredata-v3.xcdatamodel/contents
+++ b/babyry/babyry-coredata.xcdatamodeld/babyry-coredata-v3.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="5064" systemVersion="13E28" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="5064" systemVersion="13D65" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
     <entity name="AppSetting" representedClassName="AppSetting" syncable="YES">
         <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
@@ -26,7 +26,6 @@
     </entity>
     <entity name="PartnerInviteEntity" representedClassName="PartnerInviteEntity" syncable="YES">
         <attribute name="linkComplete" optional="YES" attributeType="Boolean" syncable="YES"/>
-        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="pinCode" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
     </entity>
     <entity name="TmpUserData" representedClassName="TmpUserData" syncable="YES">
@@ -54,13 +53,13 @@
     </entity>
     <elements>
         <element name="AppSetting" positionX="-45" positionY="0" width="128" height="105"/>
+        <element name="ChildPropertyEntity" positionX="-9" positionY="90" width="128" height="225"/>
         <element name="PartnerInvitedEntity" positionX="-9" positionY="90" width="128" height="73"/>
-        <element name="PartnerInviteEntity" positionX="18" positionY="126" width="128" height="88"/>
+        <element name="PartnerInviteEntity" positionX="18" positionY="126" width="128" height="73"/>
         <element name="TmpUserData" positionX="-9" positionY="63" width="128" height="133"/>
         <element name="TrackingLogEntity" positionX="27" positionY="135" width="128" height="90"/>
         <element name="TutorialAttributes" positionX="-18" positionY="99" width="128" height="75"/>
         <element name="TutorialBestShot" positionX="-9" positionY="171" width="128" height="58"/>
         <element name="TutorialStage" positionX="-18" positionY="90" width="128" height="58"/>
-        <element name="ChildPropertyEntity" positionX="-9" positionY="90" width="128" height="225"/>
     </elements>
 </model>


### PR DESCRIPTION
@hirata-motoi 

devのprovisioning profileを変更(device追加)

ログアウト時に、[PartnerApply linkComplete]が真のままな事への対応。
- ログアウト時に消すのは無し -> ひも付け完了しているユーザーに切り替えた時に逆に不具合になる
- そもそも、Parseのデータを確認してCoreDataを書き直す処理が入っていたが、CoreDataの取得方法と、bool値の判定方法にバグがあったので修正
