### PR TITLE
close PartnerWaitViewController automatically when partner apply is rejected

### DIFF
--- a/babyry/PartnerApply.h
+++ b/babyry/PartnerApply.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 
 typedef void (^CheckPartnerApplyBlock)(BOOL existsApply);
+typedef void (^RemovePartnerApplyBlock)();
 
 @interface PartnerApply : NSObject
 
@@ -17,7 +18,7 @@ typedef void (^CheckPartnerApplyBlock)(BOOL existsApply);
 + (void) unsetLinkComplete;
 + (NSNumber *) issuePinCode;
 + (void) registerApplyList;
-+ (void) removeApplyList;
++ (void) removeApplyListWithBlock:(RemovePartnerApplyBlock)block;
 + (void)checkPartnerApplyListWithBlock:(CheckPartnerApplyBlock)block;
 
 @end

--- a/babyry/PartnerApply.m
+++ b/babyry/PartnerApply.m
@@ -107,7 +107,7 @@
     }
 }
 
-+ (void) removeApplyList
++ (void) removeApplyListWithBlock:(RemovePartnerApplyBlock)block
 {
     // pinコード入力している場合(CoreDataにデータがある場合)、PartnerApplyListにレコードを入れる
     PartnerInvitedEntity *pie = [PartnerInvitedEntity MR_findFirst];
@@ -123,6 +123,8 @@
             pie.familyId = nil;
             pie.inputtedPinCode = nil;
             [[NSManagedObjectContext MR_defaultContext] MR_saveToPersistentStoreAndWait];
+            
+            block();
         }];
     }
 }

--- a/babyry/PartnerWaitViewController.m
+++ b/babyry/PartnerWaitViewController.m
@@ -86,8 +86,9 @@
                 } else {
                     [PartnerApply checkPartnerApplyListWithBlock:^(BOOL existsApply) {
                         if (!existsApply) {
-                            [PartnerApply removeApplyList];
-                            [self close];
+                            [PartnerApply removeApplyListWithBlock:^(){
+                                [self close];
+                            }];
                         }
                         _isTimerRunning = NO;
                     }];
@@ -116,8 +117,9 @@
             break;
         case 1:
         {
-            [PartnerApply removeApplyList];
-            [self close];
+            [PartnerApply removeApplyListWithBlock:^() {
+                [self close];
+            }];
         }
             break;
     }


### PR DESCRIPTION
@kenjiszk 

■以下の問題が起きていたので対応した。
PIN入力→ログイン のパターンでログインした状態で、パートナーが別のユーザと紐づいた時、いつまでたってもPartnerWaitViewControllerから進まない

■対応方法
PartnerWaitViewController checkFamilyRole内でPartnerApplyListをチェックして、レコードがなければ先に進めるように対応

■【解決済み】残っている問題
PIN入力→ログイン→取り下げ  とした時にチュートリアルが始まらない。10秒待てば自動リロードが走りチュートリアルが始まる。

→ PartnerWaitViewControllerを二回タップしないと先へ進まないのが原因。
一回目のタップで裏側ではPageContentViewControllerの構築 + overlayの表示が進むが、実際には表示されないという動作になる。これ以上詳しくは追っていないが、処理は進むがviewがaddSubviewされないというのが原因。

で、二回タップしないと先へ進まないのは非同期処理の扱いの問題。
取り下げ処理はparseのデータを非同期で削除し、そのblock処理でCoreDataを削除している。
そのため、PageWaitViewControllerを消してもCoreDataはまだ処理されておらず申請中と判断され・・・というあるあるな状態になっていた。

そこで、PageWaitViewControllerを消す処理をParse更新 + CoreData更新の後に行うように修正
