### PR TITLE
modify type of TmpUserData.isRegistered from NSNumber to BOOL

### DIFF
--- a/babyry/TmpUserData.h
+++ b/babyry/TmpUserData.h
@@ -17,6 +17,6 @@
 @property (nonatomic, retain) NSString * password;
 @property (nonatomic, retain) NSDate * createdAt;
 @property (nonatomic, retain) NSDate * updatedAt;
-@property (nonatomic, retain) NSNumber * isRegistered;
+@property (nonatomic) BOOL isRegistered;
 
 @end


### PR DESCRIPTION
@kenjiszk 
TmpUser checkRegisteredの返り値がいかんことになってたので直しましたー
TmpUserData.isRegisteredをBOOLに書き換えただけでやんす
