### PR TITLE
fix order of logout process to avoid to crash after logout

### DIFF
--- a/babyry/GlobalSettingViewController.m
+++ b/babyry/GlobalSettingViewController.m
@@ -131,14 +131,14 @@
             break;
         case 1:
         {
-            [self.navigationController popViewControllerAnimated:YES];
-            [Tutorial removeTutorialStage];
-            [ImageCache removeAllCache];
-            [TmpUser removeTmpUserFromCoreData];
-            [PartnerApply removePartnerInviteFromCoreData];
-            [PartnerApply removePartnerInvitedFromCoreData];
+            [self.navigationController popToViewController:_viewController animated:YES];
             [PushNotification removeSelfUserIdFromChannels:^(){
                 [PFUser logOut];
+                [Tutorial removeTutorialStage];
+                [ImageCache removeAllCache];
+                [TmpUser removeTmpUserFromCoreData];
+                [PartnerApply removePartnerInviteFromCoreData];
+                [PartnerApply removePartnerInvitedFromCoreData];
                 [_viewController viewDidAppear:YES];
             }];
         }

--- a/babyry/IntroMyNicknameViewController.m
+++ b/babyry/IntroMyNicknameViewController.m
@@ -259,8 +259,9 @@
     [self dismissViewControllerAnimated:YES completion:nil];
     [Tutorial removeTutorialStage];
     [ImageCache removeAllCache];
+    [PartnerApply removePartnerInviteFromCoreData];
+    [PartnerApply removePartnerInvitedFromCoreData];
     [PushNotification removeSelfUserIdFromChannels:^(){
-        NSLog(@"logout executed");
         [PFUser logOut];
     }];
 }

--- a/babyry/PageContentViewController.m
+++ b/babyry/PageContentViewController.m
@@ -154,7 +154,7 @@
         _hud = [MBProgressHUD showHUDAddedTo:self.view animated:YES];
         _hud.labelText = @"データ同期中";
     }
-    
+   
     if (![PartnerApply linkComplete]) {
         if (!_instructionTimer || ![_instructionTimer isValid]){
             _instructionTimer = [NSTimer scheduledTimerWithTimeInterval:10.0f target:self selector:@selector(reloadView) userInfo:nil repeats:YES];


### PR DESCRIPTION
@kenjiszk 

ログアウト後に落ちる問題の対応です。

昨日口頭で話した通り、原因はGlobalSettingViewControllerでのログアウト処理時に以下の処理が実行されてしまってること。
- popViewControllerAnimatedが呼ばれる
- CoreDataをクリアする
- PageContentViewControllerのviewWillAppearがよばれる
  - CoreDataが空のためPartnerApply linkCompleteがfalseになる
  - 10秒間隔の定期reloadViewが登録される
  - 10秒後にreloadViewが実行されるが既にログアウト済でPFUserが空なので落ちる(正確にはfamilyIdをwhere句に指定したクエリのところでnull指定すんなって言われてるみたい)

なので、viewWillAppearが呼ばれてからCoreDataをクリアするように対応しました。
ただし、popViewController完了時になんか処理をするにはちょっと手間がかかるので、
Installationを削除した後のblock内でCoreDataをクリアしてます(Installation削除中にviewWillAppearが呼ばれるはず)。
100%の根本対応ではないけど基本問題ないかと。
ついでに、簡単会員で始めるときのログアウト処理でも念のためPartnerApply関連のCoreDataを削除するようにしときました。
