### PR TITLE
fix logout process order to avoid recreating record after remove record

### DIFF
--- a/babyry/GlobalSettingViewController.m
+++ b/babyry/GlobalSettingViewController.m
@@ -133,13 +133,13 @@
         case 1:
         {
             [self.navigationController popViewControllerAnimated:YES onCompletion:^(void){
-                [Tutorial removeTutorialStage];
-                [ImageCache removeAllCache];
-                [TmpUser removeTmpUserFromCoreData];
-                [PartnerApply removePartnerInviteFromCoreData];
-                [PartnerApply removePartnerInvitedFromCoreData];
                 [PushNotification removeSelfUserIdFromChannels:^(){
                     [PFUser logOut];
+                    [ImageCache removeAllCache];
+                    [Tutorial removeTutorialStage];
+                    [TmpUser removeTmpUserFromCoreData];
+                    [PartnerApply removePartnerInviteFromCoreData];
+                    [PartnerApply removePartnerInvitedFromCoreData];
                     [_viewController viewDidAppear:YES];
                 }];
             }];


### PR DESCRIPTION
@kenjiszk 
ログアウト処理の順番によるバグを発見したので修正

今までのコードやとCoreDataのレコードを消した後に非同期処理によるレコード再生成が行われてたっぽいので、`[PFUser logOut];`を呼んだ後にCoreDataの掃除をするように変更しました
