### PR TITLE
fix bug of notification send timing and register flag

### DIFF
--- a/babyry/MultiUploadViewController+Logic.m
+++ b/babyry/MultiUploadViewController+Logic.m
@@ -254,11 +254,17 @@
         // ランダムでどれか1つをbestshotに選ぶ
         // TODO arc4random_uniformで得られる数値の範囲を確認
         int bestShotIndex = (int)arc4random_uniform((int)objects.count);
+        // 最後の画像のsaveが終わった段階でdidUpdatedChildImageInfoを発行する用のindex
+        int maxCount = objects.count;
+        int __block execCount = 0;
         for (int i = 0; i < objects.count; i++) {
             PFObject *childImage = objects[i];
             childImage[@"bestFlag"] = (i == bestShotIndex) ? @"choosed" : @"unchoosed";
             [childImage saveInBackgroundWithBlock:^(BOOL succeeded, NSError *error) {
-                [[NSNotificationCenter defaultCenter] postNotification: [NSNotification notificationWithName:@"didUpdatedChildImageInfo" object:self]];
+                execCount++;
+                if (execCount == maxCount) {
+                    [[NSNotificationCenter defaultCenter] postNotification: [NSNotification notificationWithName:@"didUpdatedChildImageInfo" object:self]];
+                }
             }];
         }
     }];

--- a/babyry/PageContentViewController.m
+++ b/babyry/PageContentViewController.m
@@ -199,6 +199,7 @@
     _tn = nil;
     
     [[NSNotificationCenter defaultCenter] removeObserver:self];
+    alreadyRegisteredObserver = NO;
     
     [self removeDialogs];
 }


### PR DESCRIPTION
@hirata-motoi 

ひも付けが完了していない状態で、MultiUploadでベストショット更新した時に即反映されない問題。
PageContentViewControllerのalreadyRegisteredObserverフラグがviewDidDisappearでリセットされないので一度裏になると、notificationがなくなってしまうため、ベストショット変更後に発行されるdidUpdatedChildImageInfoが受け取れていなかった。

ついでに、notificationを飛ばしまくっているところを修正(画像枚数分だけ、PageContentViewControllerをreloadしようとしてた)。
