### PR TITLE
push for ios8

### DIFF
--- a/babyry/AppDelegate.m
+++ b/babyry/AppDelegate.m
@@ -51,11 +51,23 @@
     
     // Register for push notifications
     [application unregisterForRemoteNotifications];
-    [application registerForRemoteNotificationTypes:
-     UIRemoteNotificationTypeBadge |
-     UIRemoteNotificationTypeAlert |
-     UIRemoteNotificationTypeSound |
-     UIRemoteNotificationTypeNewsstandContentAvailability];
+    NSString *currentVersion = [[UIDevice currentDevice] systemVersion];
+    if([currentVersion compare:@"8.0" options:NSNumericSearch] == NSOrderedAscending){
+        // i0S7以前の処理
+        [application registerForRemoteNotificationTypes:
+         UIRemoteNotificationTypeBadge |
+         UIRemoteNotificationTypeAlert |
+         UIRemoteNotificationTypeSound |
+         UIRemoteNotificationTypeNewsstandContentAvailability];
+    } else {
+        // iOS8の処理
+        UIUserNotificationType types = UIUserNotificationTypeBadge | UIUserNotificationTypeSound | UIUserNotificationTypeAlert;
+        
+        UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:types categories:nil];
+        
+        [application registerForRemoteNotifications];
+        [application registerUserNotificationSettings:settings];
+    }
     
     //[application setMinimumBackgroundFetchInterval:UIApplicationBackgroundFetchIntervalMinimum];
 

--- a/babyry/PushNotification.m
+++ b/babyry/PushNotification.m
@@ -71,7 +71,7 @@
                     }
                     if (!data[@"sound"]) {
                         // デフォルトの着信音
-                        data[@"sound"] = @"";
+                        data[@"sound"] = @"default";
                     }
                     [push setData:[options objectForKey:@"data"]];
                     
@@ -124,7 +124,7 @@
             }
             if (!data[@"sound"]) {
                 // デフォルトの着信音
-                data[@"sound"] = @"";
+                data[@"sound"] = @"default";
             }
             [push setData:[options objectForKey:@"data"]];
             // 送信


### PR DESCRIPTION
@hirata-motoi 

iOS8でpushの音が鳴らなかった対応。soundをdefaultにしないと駄目だった。
ついでに、registerForRemoteNotificationTypes:がiOS8から使用不可能になるので、iOS7以下との分岐を追加。
