### PR TITLE
fix bug

### DIFF
--- a/babyry/AppDelegate.m
+++ b/babyry/AppDelegate.m
@@ -9,6 +9,7 @@
 #import "AppDelegate.h"
 #import <Parse/Parse.h>
 #import <ParseFacebookUtils/PFFacebookUtils.h>
+#import <ParseCrashReporting/ParseCrashReporting.h>
 #import "PageContentViewController.h"
 #import "Crittercism.h"
 #import "Config.h"
@@ -37,6 +38,9 @@
     // CoreData
     [MagicalRecord setupCoreDataStackWithAutoMigratingSqliteStoreNamed:@"babyry.sqlite"];
     [self setupFirstLaunchUUID];
+    
+    // Parse Crash Report
+    [ParseCrashReporting enable];
     
     // Parse Authentification
     [Parse setApplicationId:[Config secretConfig][@"ParseApplicationId"] clientKey:[Config secretConfig][@"ParseClientKey"]];

--- a/babyry/MyLogInViewController.h
+++ b/babyry/MyLogInViewController.h
@@ -8,6 +8,7 @@
 
 #import <UIKit/UIKit.h>
 #import <Parse/Parse.h>
+#import <ParseUI/ParseUI.h>
 
 @interface MyLogInViewController : PFLogInViewController
 

--- a/babyry/MySignUpViewController.h
+++ b/babyry/MySignUpViewController.h
@@ -8,6 +8,7 @@
 
 #import <UIKit/UIKit.h>
 #import <Parse/Parse.h>
+#import <ParseUI/ParseUI.h>
 
 @interface MySignUpViewController : PFSignUpViewController
 


### PR DESCRIPTION
@hirata-motoi 

Parseのsdkが、1.0.5からParseUIとParseCrashReportに派生していてそれに必要なimportがマージした結果いなくなったのでそれを追加。

ついでにCrashReportを試してみます。
