### PR TITLE
fix multi upload bug and extra bugs

### DIFF
--- a/babyry/AlbumPickerViewController+Single.m
+++ b/babyry/AlbumPickerViewController+Single.m
@@ -95,8 +95,8 @@
                             [Logger writeOneShot:@"crit" message:[NSString stringWithFormat:@"Error in get image from s3 : %@", task.error]];
                             [self showSingleUploadError];
                         } else {
-                            [self afterSingleUploadComplete:resizedImage dirName:[NSString stringWithFormat:@"ChildImage%ld", (long)[_albumPickerViewController.childProperty[@"childImageShardIndex"] integerValue]] imageObjectId:childImage.objectId];
                             dispatch_async(dispatch_get_main_queue(), ^{
+                                [self afterSingleUploadComplete:resizedImage dirName:[NSString stringWithFormat:@"ChildImage%ld", (long)[_albumPickerViewController.childProperty[@"childImageShardIndex"] integerValue]] imageObjectId:childImage.objectId];
                                 [_albumPickerViewController dismissViewControllerAnimated:YES completion:nil];
                                 //アルバム表示のViewも消す
                                 UINavigationController *naviController = (UINavigationController *)_albumPickerViewController.presentingViewController;

--- a/babyry/AlbumPickerViewController.h
+++ b/babyry/AlbumPickerViewController.h
@@ -45,8 +45,6 @@
 @property NSMutableArray *totalImageNum;
 @property NSIndexPath *targetDateIndexPath;
 
-@property MBProgressHUD *hud;
-
 @property int multiUploadMax;
 
 @property NSString *uploadType;

--- a/babyry/AlbumPickerViewController.m
+++ b/babyry/AlbumPickerViewController.m
@@ -50,8 +50,6 @@
     _childProperty = [ChildProperties getChildProperty:_childObjectId];
     cellSize = CGSizeMake(self.view.frame.size.width/4 -3, self.view.frame.size.width/4 -3);
     selectedCellSize = CGSizeMake(_selectedImageCollectionView.frame.size.height, _selectedImageCollectionView.frame.size.height);
-    _hud = [MBProgressHUD showHUDAddedTo:self.view animated:YES];
-    [_hud hide:YES];
     
     _albumImageCollectionView.delegate = self;
     _albumImageCollectionView.dataSource = self;

--- a/babyry/MyLogInViewController.m
+++ b/babyry/MyLogInViewController.m
@@ -50,7 +50,7 @@
     [self.logInView addSubview:buttonView];
     UITapGestureRecognizer *dismisGesture = [[UITapGestureRecognizer alloc]initWithTarget:self action:@selector(dismisViewController)];
     dismisGesture.numberOfTapsRequired = 1;
-    [self.logInView addGestureRecognizer:dismisGesture];
+    [buttonView addGestureRecognizer:dismisGesture];
     
     // ログインボタン設定
     [self.logInView.logInButton setBackgroundColor:[ColorUtils getPositiveButtonColor]];

--- a/babyry/MySignUpViewController.m
+++ b/babyry/MySignUpViewController.m
@@ -36,7 +36,7 @@
     [self.view addSubview:buttonView];
     UITapGestureRecognizer *dismisGesture = [[UITapGestureRecognizer alloc]initWithTarget:self action:@selector(dismisViewController)];
     dismisGesture.numberOfTapsRequired = 1;
-    [self.signUpView addGestureRecognizer:dismisGesture];
+    [buttonView addGestureRecognizer:dismisGesture];
     
     // タイトル
     signUpViewTitle = [[UILabel alloc] initWithFrame:CGRectMake(0, 50, 320, 44)];


### PR DESCRIPTION
@hirata-motoi 

ちょいちょいバグフィックス
- MultiUploadでたまーにクルクルしっ放し問題
  BFTaskをwithBlockじゃなくて呼ぶとエラーでもエラーが返ってこないみたいなので、continueWithBlockで呼ぶようにした。で、dispatchうんぬんの中でBFTask withBlockするとスレッドのカウントとかがよくわからない状態になるので、dispatch云々は消して、普通にforでバックグラウンドの処理を回す事にした。そもそも写真枚数の上限を設定しているのでこれで良しとする。
- アップロードボタンおしたらクルクル出すようにする
  UI処理以外はメインスレッドから追い出した。
- ログイン、サインインViewでdismisのジェスチャーが×ボタンについてなかった
  普通にバグだった。
