### PR TITLE
fix yesterday judge bug

### DIFF
--- a/babyry/DateUtils.m
+++ b/babyry/DateUtils.m
@@ -169,6 +169,14 @@
     if (index.section == 0 && (index.row == 0 || index.row == 1)) {
         return YES;
     }
+
+    // 今日が1日の場合、昨日がsection=1, row=0の時がある
+    if (index.section == 1 && index.row == 0) {
+        NSIndexPath *yesterdayIndex = [self getIndexPathFromDate:[self getYesterdayYMD]];
+        if (index.section == yesterdayIndex.section && index.row == yesterdayIndex.row) {
+            return YES;
+        }
+    }
     return NO;
 }
 


### PR DESCRIPTION
@hirata-motoi 

今日が1日の場合、昨日のcellの判定に失敗していた。
昨日のcellがsection = 1, row = 0になるため。

その時の判定を追加。
iPhoneの時間を1日ずらしても、[self getYesterdayYMD]が一日ずれていない正しい値を持ってきてしまっていたので、検証はどうしたものかと思っているところ。
