### PR TITLE
fix image loading bug

### DIFF
--- a/babyry/PageContentViewController+Logic.m
+++ b/babyry/PageContentViewController+Logic.m
@@ -102,6 +102,7 @@
             NSNumber *indexNumber = [self.pageContentViewController.childImagesIndexMap objectForKey:[NSString stringWithFormat:@"%ld%02ld", (long)year, (long)month]];
             if (!indexNumber) {
                 [self.pageContentViewController.hud hide:YES];
+                self.pageContentViewController.isLoading = NO;
                 return;
             }
             NSInteger index = [indexNumber integerValue];
@@ -219,6 +220,7 @@
             [Logger writeOneShot:@"crit" message:[NSString stringWithFormat:@"Error in getChildImagesWithYear : %@", error]];
             [self.pageContentViewController.hud hide:YES];
             [self.pageContentViewController showAlertMessage];
+            self.pageContentViewController.isLoading = NO;
         }
     }];
     // 不要なfullsizeのキャッシュを消す

--- a/babyry/PageContentViewController.m
+++ b/babyry/PageContentViewController.m
@@ -715,6 +715,7 @@
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         [self addChildImagesFirstWithStartDateComps:startDateComps withEndDateComps:twoMonthAndOneDayAgo];
         dispatch_async(dispatch_get_main_queue(), ^{
+            [self setupChildImagesIndexMap];
             [_pageContentCollectionView reloadData];
             [self initializeClosedCellCountBySection];
     });


### PR DESCRIPTION
@hirata-motoi 

2点ほど、画像のloadingのバグfix
- getChildImagesWithYearの中で例外が起きた時に、isLoadingフラグがOFFにならないので、次回以降読み込んでくれない
- サクサク動作のためchildImagesを2段階に分けてロードするようにしたため、imageIndexMapも対応して作り直すようにした(いままでは1段階目の時だけ作っていたので3ヶ月分しか無かった)
