### PR TITLE
update osirase logic

### DIFF
--- a/babyry/GlobalSettingViewController.m
+++ b/babyry/GlobalSettingViewController.m
@@ -170,6 +170,7 @@
     cell.textLabel.text = nil;
     cell.detailTextLabel.text = nil;
     cell.accessoryType = UITableViewCellAccessoryNone;
+    cell.selectionStyle = UITableViewCellSelectionStyleDefault;
     cell.textLabel.numberOfLines = 0;
     cell.textLabel.font = [UIFont fontWithName:@"HiraKakuProN-W3" size:14];
     cell.separatorInset = UIEdgeInsetsZero;
@@ -189,14 +190,20 @@
                 hud = [MBProgressHUD showHUDAddedTo:cell animated:YES];
                 [cell addSubview:hud];
             } else {
+                if (notificationHistoryArray.count == 0) {
+                    cell.selectionStyle = UITableViewCellSelectionStyleNone;
+                    break;
+                }
                 if (indexPath.row == 4) {
                     cell.detailTextLabel.text = @"お知らせをもっと見る";
                     cell.detailTextLabel.textAlignment = NSTextAlignmentRight;
                     cell.detailTextLabel.font = cell.textLabel.font;
                     cell.detailTextLabel.textColor = [UIColor blackColor];
                     cell.backgroundColor = [ColorUtils getGlobalMenuLightGrayColor];
+                    cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+                    cell.selectionStyle = UITableViewCellSelectionStyleDefault;
                 } else {
-                    if (notificationHistoryArray.count > 0 && notificationHistoryArray[indexPath.row]) {
+                    if (notificationHistoryArray.count > indexPath.row) {
                         PFObject *histObject = notificationHistoryArray[indexPath.row];
                         cell.textLabel.text = [NotificationHistory getNotificationString:histObject];
                         cell.textLabel.numberOfLines = 2;
@@ -213,10 +220,12 @@
                         if (![histObject[@"status"] isEqualToString:@"displayed"]) {
                             cell.backgroundColor = [ColorUtils getGlobalMenuDarkGrayColor];
                         }
+                        cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+                        cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+                    } else {
+                        cell.selectionStyle = UITableViewCellSelectionStyleNone;
                     }
                 }
-                cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-                cell.selectionStyle = UITableViewCellSelectionStyleDefault;
             }
             break;
         case 1:
@@ -312,13 +321,16 @@
     
     switch (indexPath.section) {
         case 0:
+            if (notificationHistoryArray.count == 0) {
+                break;
+            }
             if (notificationHistoryArray) {
                 if (indexPath.row == 4) {
                     [self openNotificationHistoryViewController];
-                } else {
+                } else if (notificationHistoryArray.count > indexPath.row) {
                     if (notificationHistoryArray[indexPath.row]) {
                         PFObject *histObject = notificationHistoryArray[indexPath.row];
-                        [TransitionByPushNotification createTransitionInfoAntTransition:histObject viewController:self];
+                        [TransitionByPushNotification createTransitionInfoAndTransition:histObject viewController:self];
                     }
                 }
             }
@@ -613,14 +625,7 @@
 - (void)getNotificationHistory
 {
     [NotificationHistory getNotificationHistoryInBackground:[PFUser currentUser][@"userId"] withType:nil withChild:nil withStatus:nil withLimit:100 withBlock:^(NSArray *objects){
-        notificationHistoryArray = [[NSMutableArray alloc] init];
-        // imageUploaded, requestPhoto, bestShotChanged, commentPostedだけ拾う
-        // その他のやつはhistoryにある意味が無いので(partchangeはかってにスイッチされてるとか)
-        for (PFObject *object in objects) {
-            if ([[Config config][@"GlobalNotificationTypes"] containsObject:object[@"type"]]) {
-                [notificationHistoryArray addObject:object];
-            }
-        }
+        notificationHistoryArray = [[NSMutableArray alloc] initWithArray:objects];
         [_settingTableView reloadData];
         [hud hide:YES];
     }];

--- a/babyry/NotificationHistoryViewController.m
+++ b/babyry/NotificationHistoryViewController.m
@@ -107,7 +107,7 @@
     [tableView deselectRowAtIndexPath:indexPath animated:YES]; // 選択状態の解除
     
     PFObject *histObject = _notificationHistoryArray[indexPath.row];
-    [TransitionByPushNotification createTransitionInfoAntTransition:histObject viewController:self];
+    [TransitionByPushNotification createTransitionInfoAndTransition:histObject viewController:self];
 }
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView
@@ -145,14 +145,7 @@
 - (void)getNotificationHistory
 {
     [NotificationHistory getNotificationHistoryInBackground:[PFUser currentUser][@"userId"] withType:nil withChild:nil withStatus:nil withLimit:100 withBlock:^(NSArray *objects){
-        _notificationHistoryArray = [[NSMutableArray alloc] init];
-        // imageUploaded, requestPhoto, bestShotChanged, commentPostedだけ拾う
-        // その他のやつはhistoryにある意味が無いので(partchangeはかってにスイッチされてるとか)
-        for (PFObject *object in objects) {
-            if ([[Config config][@"GlobalNotificationTypes"] containsObject:object[@"type"]]) {
-                [_notificationHistoryArray addObject:object];
-            }
-        }
+        _notificationHistoryArray = [[NSMutableArray alloc] initWithArray:objects];
         [_notificationTableView reloadData];
     }];
 }

--- a/babyry/PageContentViewController+Logic.m
+++ b/babyry/PageContentViewController+Logic.m
@@ -303,15 +303,7 @@
 - (void) showGlobalMenuBadge
 {
     [NotificationHistory getNotificationHistoryInBackground:[PFUser currentUser][@"userId"] withType:nil withChild:nil withStatus:@"ready" withLimit:1000 withBlock:^(NSArray *objects){
-        int badgeNumber = 0;
-        // imageUploaded, requestPhoto, bestShotChanged, commentPostedだけ拾う
-        // その他のやつはhistoryにある意味が無いので(partchangeはかってにスイッチされてるとか)
-        for (PFObject *object in objects) {
-            if ([[Config config][@"GlobalNotificationTypes"] containsObject:object[@"type"]]) {
-                badgeNumber++;
-            }
-        }
-        [self.pageContentViewController.delegate setGlobalMenuBadge:badgeNumber];
+        [self.pageContentViewController.delegate setGlobalMenuBadge:[objects count]];
     }];
 }
 

--- a/babyry/TransitionByPushNotification.h
+++ b/babyry/TransitionByPushNotification.h
@@ -27,6 +27,6 @@
 + (void) setAppLaunchedFlag;
 + (void) removeAppLaunchFlag;
 + (BOOL) checkAppLaunchedFlag;
-+ (void)createTransitionInfoAntTransition:(PFObject *)histObject viewController:(UIViewController *)vc;
++ (void)createTransitionInfoAndTransition:(PFObject *)histObject viewController:(UIViewController *)vc;
 
 @end

--- a/babyry/TransitionByPushNotification.m
+++ b/babyry/TransitionByPushNotification.m
@@ -305,7 +305,7 @@ static BOOL appLaunchFlag = NO;
 }
 
 // globalSettingのお知らせから飛ぶ用で、Push後の遷移ではないが同じ遷移をするようにtransitionInfoを偽装
-+ (void)createTransitionInfoAntTransition:(PFObject *)histObject viewController:(UIViewController *)vc
++ (void)createTransitionInfoAndTransition:(PFObject *)histObject viewController:(UIViewController *)vc
 {
     NSMutableDictionary *transitionInfoDic = [[NSMutableDictionary alloc] init];
     if ([histObject[@"type"] isEqualToString:@"commentPosted"]) {


### PR DESCRIPTION
@hirata-motoi 

お知らせの見せ方の改修&バグfix
- おしらせの見せ方をまとめてみせるようにした
  - 今まではnotificationHistory 1行をそのまま表示していたけど、同じ子供、同じ日付でまとめた
  - まとめた行の中で一番新しいcreatedAtを代表にして、その値の降順で表示させる
  - 2日以上前の写真アップ、GMPは意味が無いので表示しない
  - ついたコメント数はお知らせに表示させるが、アップ数は同時アップの枚数とnotificationHistoryの行数が一致しないので表示させない
- bug fix
  - お知らせが一見も無い時には空欄をだしてタップも出来ないようにした(今までは落ちてた)
  - 過去にベストショットが決められていたがその画像がパートナーによって消された場合、お知らせからその画像に飛ぶと何も表示されないので、その旨のアラートを出すようにして、notificationHistoryも消すようにした。
