### PR TITLE
fix bug of same image duplicate uploading

### DIFF
--- a/babyry/MultiUploadViewController+Logic.m
+++ b/babyry/MultiUploadViewController+Logic.m
@@ -60,7 +60,7 @@
                     queue[@"objectId"] = object.objectId;
                     queue[@"childObjectId"] = _multiUploadViewController.childObjectId;
                     queue[@"date"] = object[@"date"];
-                    queue[@"imageType"] = @"candidate";
+                    queue[@"isCandidate"] = [NSNumber numberWithBool:YES];
                     [downloadQueue addObject:queue];
                 }
             }

--- a/babyry/PageContentViewController+Logic.m
+++ b/babyry/PageContentViewController+Logic.m
@@ -132,8 +132,9 @@
                                 queueForCache[@"objectId"] = childImageDate.objectId;
 								queueForCache[@"childObjectId"] = self.pageContentViewController.childObjectId;
                                 queueForCache[@"date"] = childImageDate[@"date"];
+                                queueForCache[@"isBS"] = [NSNumber numberWithBool:YES];
                                 if ([DateUtils isTodayByIndexPath:ip]) {
-                                    queueForCache[@"imageType"] = @"fullsize";
+                                    queueForCache[@"isFullSize"] = [NSNumber numberWithBool:YES];
                                 }
                                 
                                 [cacheSetQueueArray addObject:queueForCache];
@@ -152,7 +153,7 @@
                                 queueForCache[@"objectId"] = childImageDate.objectId;
 								queueForCache[@"childObjectId"] = self.pageContentViewController.childObjectId;
                                 queueForCache[@"date"] = childImageDate[@"date"];
-								queueForCache[@"imageType"] = @"candidate";
+								queueForCache[@"isCandidate"] = [NSNumber numberWithBool:YES];
                                 
                                 [cacheSetQueueArray addObject:queueForCache];
                             }


### PR DESCRIPTION
@hirata-motoi 

サムネイルの作成に失敗している問題の対応
(多分これじゃないかなと思うけど、100%の確信は無い)

downloadQueueを作る時に、キャッシュの作り方でimateTypeに色々な値を入れていたが、その影響で、全く同じファイルを同時にダウンロードしていた。
おそらくだけど、AWSのSDKのバグ(or 仕様)で同名ファイルを同時にダウンロードするとこれがおこるんじゃないかと思っている。
(完全に勘だけど、ダウンロードのkeyで固有のidentifier的なものを作ってるんじゃないかなあと。で、全く同じファイルを一度にダウンロードするとそれが被るからおかしくなりそう)

そもそも同じファイルを2回ダウンロードしていて無駄だったのでそれも含めて修正しました。
