### PR TITLE
insert adjustChildImages in ViewDidAppear

### DIFF
--- a/babyry/PageContentViewController.m
+++ b/babyry/PageContentViewController.m
@@ -184,6 +184,8 @@
     if (childProperty[@"name"]) {
         [_delegate updateNavitagionTitle:childProperty[@"name"]];
     }
+    
+    [self adjustChildImages];
 }
 
 - (void)reloadView


### PR DESCRIPTION
@hirata-motoi 

日付が切り替わった時にカレンダーが切り替わらないバグの対応。

今までは、PageContentViewControllerがpageviewの切り替えで切り替えられていたため、viewDidLoadが必ず呼ばれてadjustChildImagesが呼ばれていたが、今はその方式ではないので、viewDidAppearのなかでadjustChildImagesを呼ぶようにした。
