### PR TITLE
change donwload file name

### DIFF
--- a/babyry/AWSS3Utils.m
+++ b/babyry/AWSS3Utils.m
@@ -117,6 +117,7 @@
     AWSS3TransferManagerDownloadRequest *downloadRequest = [AWSS3TransferManagerDownloadRequest new];
     downloadRequest.bucket = [Config config][@"AWSBucketName"];
     downloadRequest.key = key;
+    downloadRequest.downloadingFileURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:[key stringByReplacingOccurrencesOfString:@"/" withString:@"_"]]];
     downloadRequest.responseCacheControl = @"no-cache";
     
     [[transferManager download:downloadRequest] continueWithExecutor:[BFExecutor mainThreadExecutor] withBlock:^id(BFTask *task) {


### PR DESCRIPTION
@hirata-motoi 

子供のアイコンが正しく表示されない事のバグフィックス
AWSのダウンロードのスレッド云々全く関係なかったw まさかの一行pull reqになります。

原因は、AWS上のアイコンのファイル名が全て同じ"1"なので、iPhoneのtmpディレクトリ上に
1
1 (1)
1 (2)
1 (3)
みたいになっていたこと。
複数のダウンロード処理が同時に走ると、みんなが同名のファイルで保存しようとするのでファイルが混ざってしまうような状態になった。
1. tmp内のファイル名確認
2. ()内の数字を決める
3. ファイル書き出し

1~3のタイミングが被った。特に1のタイミングがいつかによって大分被りやすい状態になるとおもうがそれはOS依存なのでそこまで追わない。

多分子供が多いほど起きやすいのは、タイミングが同じになりやすいからではないかなと思う。

絶対被らない名前に変えて修正done。
