### PR TITLE
Moved saving process to main thread

### DIFF
--- a/babyry/AlbumPickerViewController+Multi.m
+++ b/babyry/AlbumPickerViewController+Multi.m
@@ -112,15 +112,14 @@
                                                   indexPath:_albumPickerViewController.targetDateIndexPath];
         NSNotification *n = [NSNotification notificationWithName:@"multiUploadImageInBackground" object:nil];
         [[NSNotificationCenter defaultCenter] postNotification:n];
-        
-        if ([[Tutorial currentStage].currentStage isEqualToString:@"uploadByUser"]) {
-            [Tutorial forwardStageWithNextStage:@"uploadByUserFinished"];
-        }
-        
+       
         // child icon
         [_albumPickerViewController setChildFirstIconWithImageData:_albumPickerViewController.uploadImageDataArray[0]]; // 決め
         
         dispatch_async(dispatch_get_main_queue(), ^{
+            if ([[Tutorial currentStage].currentStage isEqualToString:@"uploadByUser"]) {
+                [Tutorial forwardStageWithNextStage:@"uploadByUserFinished"];
+            }
             [_albumPickerViewController dismissViewControllerAnimated:YES completion:NULL];
         
             //アルバム表示のViewも消す


### PR DESCRIPTION
@kenjiszk 
チュートリアルが写真アップしたところで止まってしまう問題の対応

楽勝pull reqなので軽くレビューおねがいしゃっす
- 原因
  - `[NSManagedObjectContext MR_defaultContext]`はmain threadでしか動かないが、dispatch_get_global_queueを使って裏のthreadで実行していた
  - https://github.com/magicalpanda/MagicalRecord/wiki/Working-with-Managed-Object-Contexts
- 対応
  - 更新処理をmain threadで呼び出すように変更
