### PR TITLE
fix setting system timezone

### DIFF
--- a/babyry.xcodeproj/project.pbxproj
+++ b/babyry.xcodeproj/project.pbxproj
@@ -2271,7 +2271,7 @@
 				INFOPLIST_FILE = "babyry/babyrydev-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				PRODUCT_NAME = babyry;
-				PROVISIONING_PROFILE = "6dc1d57d-479a-4d0c-98b1-c7405f9bb096";
+				PROVISIONING_PROFILE = "545fc447-ec71-4bdb-9814-a5a5ee928d84";
 				VALID_ARCHS = "arm64 armv7 armv7s";
 				WRAPPER_EXTENSION = app;
 			};

--- a/babyry/DateUtils.m
+++ b/babyry/DateUtils.m
@@ -148,12 +148,12 @@
 
 + (NSNumber *)getTodayYMD
 {
-    return [self numberFromComps:[self dateCompsFromDate:[self setSystemTimezone:[NSDate date]]]];
+    return [self numberFromComps:[self dateCompsFromDate:[NSDate date]]];
 }
 
 + (NSNumber *)getYesterdayYMD
 {
-    return [self numberFromComps:[self dateCompsFromDate:[self setSystemTimezone:[NSDate dateWithTimeIntervalSinceNow:-24*60*60]]]];
+    return [self numberFromComps:[self dateCompsFromDate:[NSDate dateWithTimeIntervalSinceNow:-24*60*60]]];
 }
 
 + (BOOL)isTodayByIndexPath:(NSIndexPath *)index
@@ -184,7 +184,7 @@
 {
     // yyyymmddからindexPathを構築する
     NSDateComponents *targetComps = [self compsFromNumber:date];
-    NSDateComponents *todayComps = [self dateCompsFromDate:nil];
+    NSDateComponents *todayComps = [self compsFromNumber:[self getTodayYMD]];
     
     int section = 0;
     int row = 0;


### PR DESCRIPTION
@hirata-motoi 

GiveMePhotoの日付がずれる問題
DateUtilsのgetTodayYMDやgetYesterdayYMDの中で、dateCompsFromDateが使われているが、このメソッド内でtimezoneの補正がされるうえに、引数に渡すdateがtimezoneの補正をしていると結果的に時計が+9時間すすむ(+9の補正が2回)。
そのため、15時以降にGMPをだすと次の日のリクエストとして扱われていた。

ついでに、getIndexPathFromDateは逆に日付の補正がされていなかったのでした。
