### PR TITLE
return only push info exist

### DIFF
--- a/babyry.xcodeproj/project.pbxproj
+++ b/babyry.xcodeproj/project.pbxproj
@@ -2271,7 +2271,7 @@
 				INFOPLIST_FILE = "babyry/babyrydev-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				PRODUCT_NAME = babyry;
-				PROVISIONING_PROFILE = "6dc1d57d-479a-4d0c-98b1-c7405f9bb096";
+				PROVISIONING_PROFILE = "545fc447-ec71-4bdb-9814-a5a5ee928d84";
 				VALID_ARCHS = "arm64 armv7 armv7s";
 				WRAPPER_EXTENSION = app;
 			};

--- a/babyry/ViewController.m
+++ b/babyry/ViewController.m
@@ -125,6 +125,7 @@
         NSDictionary *transitionInfo = [TransitionByPushNotification getInfo];
         if ([transitionInfo count] > 0) {
             [TransitionByPushNotification returnToTop:self];
+            return;
         }
     }
 }
@@ -174,14 +175,15 @@
         
     } else {
         if ([TransitionByPushNotification isReturnedToTop]) {
+            // 別ViewからTopに戻っていたら無条件でdispatch
             [TransitionByPushNotification dispatch:self];
             return;
         } else if ([TransitionByPushNotification checkAppLaunchedFlag]) {
+            // push通知から起動した場合にappLaunchflagがセットされる
             [TransitionByPushNotification removeAppLaunchFlag];
             [self applicationDidReceiveRemoteNotification];
-            return;
         }
-
+        
         // メンテナンス状態かどうか確認
         // バックグラウンドで行わないと一瞬固まる
         PFQuery *maintenanceQuery = [PFQuery queryWithClassName:@"Config"];


### PR DESCRIPTION
@hirata-motoi 

push経由で初期起動した場合に、トップに戻るとクルクルがずっと出続ける件のfix。
transitionInfoが空の場合はそのまま処理を続けないといけないのに、空でもreturnをしてしまっていたのでトップが正常に表示されていなかった。
