### PR TITLE
fix brink global badge icon

### DIFF
--- a/babyry/PageContentViewController+Logic.m
+++ b/babyry/PageContentViewController+Logic.m
@@ -33,6 +33,7 @@
     [self updateChildProperties];
     [Comment updateCommentNumEntity];
     [self removeUnnecessaryGMPBadge];
+    [self showGlobalMenuBadge];
 }
 
 - (void)showChildImages
@@ -305,7 +306,9 @@
 
 - (void) showGlobalMenuBadge
 {
+    [self.pageContentViewController.delegate setGlobalMenuBadge:self.pageContentViewController.badgeNumber];
     [NotificationHistory getNotificationHistoryInBackground:[PFUser currentUser][@"userId"] withType:nil withChild:nil withStatus:@"ready" withLimit:1000 withBlock:^(NSArray *objects){
+        self.pageContentViewController.badgeNumber = [objects count];
         [self.pageContentViewController.delegate setGlobalMenuBadge:[objects count]];
     }];
 }

--- a/babyry/PageContentViewController.h
+++ b/babyry/PageContentViewController.h
@@ -88,4 +88,6 @@
 
 @property NSMutableDictionary *bestImageIds;
 
+@property int badgeNumber;
+
 @end

--- a/babyry/PageContentViewController.m
+++ b/babyry/PageContentViewController.m
@@ -108,6 +108,8 @@
     
     alreadyRegisteredObserver = NO;
     
+    _badgeNumber = 0;
+    
     _hud = [MBProgressHUD showHUDAddedTo:self.view animated:YES];
     _hud.hidden = YES;
 	


### PR DESCRIPTION
@hirata-motoi 

global settingのバッヂがチカチカする問題への対応。
badgeNumberをキャッシュしておいて、読み込み中も表示させておくように修正。
