### PR TITLE
remove iconImage before page transition

### DIFF
--- a/babyry/PageContentViewController.m
+++ b/babyry/PageContentViewController.m
@@ -233,6 +233,8 @@
     alreadyRegisteredObserver = NO;
     
     [self removeDialogs];
+    
+    iconImage = nil;
 }
 
 - (id)logic:(NSString *)methodName


### PR DESCRIPTION
@hirata-motoi 

背景の子供のブラーイメージが即反影されない問題。
表示を早くする為にiconImageにキャッシュを保存しておく形式だったが、子供のアイコンを変えてもそこのキャッシュを使い続けていた。
PageContentViewControllerのviewWillDisAppearでキャッシュを破棄するように変更。
