### PR TITLE
set default selectedItemNumber

### DIFF
--- a/babyry/ChildCreatePopupViewController.m
+++ b/babyry/ChildCreatePopupViewController.m
@@ -182,7 +182,7 @@
         } else if ([c isKindOfClass:[ChildProfileGenderCell class]]) {
             // TODO cellで管理する
             ChildProfileGenderCell *cell = (ChildProfileGenderCell *)c;
-            if (cell.segmentControl.selected) {
+            if (cell.segmentControl.selectedSegmentIndex != -1) {
                 childInfo[@"sex"] = (cell.segmentControl.selectedSegmentIndex == 0) ? @"female" : @"male";
             }
         } else if ([c isKindOfClass:[ChildProfileBirthdayCell class]]) {

--- a/babyry/GenderSegmentControl.m
+++ b/babyry/GenderSegmentControl.m
@@ -29,6 +29,8 @@
             self.selectedSegmentIndex = 0;
         } else if ([params[@"gender"] isEqualToString:@"male"]) {
             self.selectedSegmentIndex = 1;
+        } else {
+            self.selectedSegmentIndex = -1;
         }
         
         self.frame = CGRectMake(0, 0, 100, 25);


### PR DESCRIPTION
@hirata-motoi 

子供追加時に、性別が反影されない問題の対応。

cell.segmentControl.selectedが、segmentControllerが押されたかどうかではなく、デフォルトで選択した状態かどうかを表していた為に、押した場合でもif (cell.segmentControl.selected)が常に偽だった。
デフォルトのcell.segmentControl.selectedSegmentIndexを-1にした上で、-1でない場合には子供の性別が選択されたものとして処理を進めるように変更。
